### PR TITLE
chore: ignore venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ __pycache__
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+venv/
+.venv/


### PR DESCRIPTION
Ignore local virtual environment directory to keep repository clean.